### PR TITLE
removes redundant definition of DB from spec file

### DIFF
--- a/spec/student_spec.rb
+++ b/spec/student_spec.rb
@@ -2,7 +2,6 @@ require_relative 'spec_helper'
 
 describe Student do
   before :each do
-    DB = {:conn => SQLite3::Database.new("db/students.db")}
     DB[:conn].execute("DROP TABLE IF EXISTS students")
 
     sql = <<-SQL


### PR DESCRIPTION
DB constant is already defined in config/environment.rb, so this redundant definition throws an error when the test suite is run.
